### PR TITLE
Add SQL init script for Postgres

### DIFF
--- a/migrations/init.sql
+++ b/migrations/init.sql
@@ -1,0 +1,4 @@
+-- Initial PostgreSQL setup for Trading Duel
+-- Create required extensions if they are not already installed
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";


### PR DESCRIPTION
## Summary
- add `migrations/init.sql` to set up required PostgreSQL extensions

## Testing
- `yarn --version` *(fails: unable to download yarn)*