### PR TITLE
Fix lint warning in trade-monitor

### DIFF
--- a/services/oracle/src/trade-monitor.ts
+++ b/services/oracle/src/trade-monitor.ts
@@ -1,4 +1,4 @@
-import { Connection, PublicKey, GetProgramAccountsFilter, Keypair } from '@solana/web3.js';
+import { Connection, PublicKey, Keypair } from '@solana/web3.js';
 import { BN } from '@coral-xyz/anchor';
 import { TradingDuelClient } from '../../../client/src/program';
 import { Jupiter } from '@jup-ag/api';


### PR DESCRIPTION
## Summary
- remove unused `GetProgramAccountsFilter` import to prevent lint errors

## Testing
- `yarn lint:fix` *(fails: Connect Timeout Error)*